### PR TITLE
[HLH][121409265] Convert Plugin to ES6

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,54 +3,76 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var fs = require('fs');
-var SVGSpriter = require('svg-sprite');
 
-function SvgSprite(options) {
-  var defaultOptions = {
-    filename: 'svg-sprite.svg'
-  };
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-  this.options = Object.assign({}, defaultOptions, options);
-}
+var _fs = require('fs');
 
-SvgSprite.prototype.apply = function (compiler) {
-  var config = this.options;
+var _fs2 = _interopRequireDefault(_fs);
 
-  compiler.plugin('emit', function (compilation, callback) {
-    var svgs = compilation.fileDependencies.filter(function (file) {
-      return file.match(/svg$/);
-    });
+var _svgSprite = require('svg-sprite');
 
-    var spriter = new SVGSpriter({
-      mode: { symbol: true },
-      shape: { transform: [] }
-    });
+var _svgSprite2 = _interopRequireDefault(_svgSprite);
 
-    svgs.forEach(function (svg) {
-      spriter.add(svg, null, fs.readFileSync(svg, { encoding: 'utf-8' }));
-    });
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-    spriter.compile(function (err, result) {
-      if (err) {
-        throw err;
-      }
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-      var contents = result.symbol.sprite.contents.toString('utf-8');
-
-      compilation.assets[config.filename] = {
-        source: function source() {
-          return contents;
-        },
-        size: function size() {
-          return contents.length;
-        }
-      };
-    });
-
-    callback();
-  });
+var DEFAULT_OPTIONS = {
+  filename: 'svg-sprite.svg'
 };
 
-exports.default = SvgSprite;
+var SvgSpritePlugin = function () {
+  function SvgSpritePlugin(options) {
+    _classCallCheck(this, SvgSpritePlugin);
+
+    this.options = Object.assign({}, DEFAULT_OPTIONS, options);
+  }
+
+  _createClass(SvgSpritePlugin, [{
+    key: 'apply',
+    value: function apply(compiler) {
+      var filename = this.options.filename;
+
+
+      compiler.plugin('emit', function (compilation, done) {
+        var svgs = compilation.fileDependencies.filter(function (file) {
+          return file.match(/\.svg$/);
+        });
+
+        var spriter = new _svgSprite2.default({
+          mode: { symbol: true },
+          shape: { transform: [] }
+        });
+
+        svgs.forEach(function (svg) {
+          spriter.add(svg, null, _fs2.default.readFileSync(svg, { encoding: 'utf-8' }));
+        });
+
+        spriter.compile(function (err, result) {
+          if (err) {
+            throw err;
+          }
+
+          var contents = result.symbol.sprite.contents.toString('utf-8');
+
+          compilation.assets[filename] = {
+            source: function source() {
+              return contents;
+            },
+            size: function size() {
+              return contents.length;
+            }
+          };
+
+          done();
+        });
+      });
+    }
+  }]);
+
+  return SvgSpritePlugin;
+}();
+
+exports.default = SvgSpritePlugin;
 module.exports = exports['default'];

--- a/test/dummy/webpack.test.config.js
+++ b/test/dummy/webpack.test.config.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import SvgSprite from '../../index'
+import SvgSprite from '../../src'
 
 module.exports = {
   entry: path.join(__dirname, 'entry.js'),


### PR DESCRIPTION
Converted the plugin to use ES6 syntax. 

Only notable changes are moving the `done()` callback to inside of the `spriter` callback, to ensure we don't end up with an odd timing issue where the spriter finishes too late. As well as updating the dummy config to pull the src version of the plugin rather than having to build for each test.